### PR TITLE
Prepares gem name for rubygems publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Rack middleware for converting the params keys and JSON response keys of a Rac
 
 Add this line to your application's Gemfile:
 
-    gem 'sparrow'
+    gem 'cp-sparrow', require: 'sparrow'
 
 And then execute:
 

--- a/sparrow.gemspec
+++ b/sparrow.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'sparrow/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = "sparrow"
+  spec.name        = "cp-sparrow"
   spec.version     = Sparrow::VERSION
   spec.authors     = ["Daniel Schmidt", "Andreas Müller"]
   spec.email       = ["dsci@code79.net", "anmuel86@gmail.com"]


### PR DESCRIPTION
Currently the gem name "sparrow" clashes with an existing gem. This commit renames the gem and changes the Readme accordingly.