### PR TITLE
Decide the response-strategy based on the response content-type

### DIFF
--- a/lib/sparrow/middleware.rb
+++ b/lib/sparrow/middleware.rb
@@ -24,12 +24,10 @@ module Sparrow
 
     def strategy
       if is_processable?
-        if last_env[Strategies::FormHash::REQUEST_FORM_HASH_KEY]
-          Strategies::FormHash
-        else
-          Strategies::RawInput
-        end
+        Rails.logger.debug 'Choosing strategy RawInput' if defined? Rails
+        Strategies::RawInput
       else
+        Rails.logger.debug 'Choosing strategy Ignore' if defined? Rails
         Strategies::Ignore
       end
     end
@@ -44,7 +42,7 @@ module Sparrow
     end
 
     def accepted_content_type?
-      content_type_equals?(request_content_type) || content_type_matches?(request_content_type)
+      content_type_equals?(content_type) || content_type_matches?(content_type)
     end
 
     def accepted_accept_header?
@@ -66,15 +64,6 @@ module Sparrow
                       end
 
       request_class.new(last_env)
-    end
-
-    def request_content_type
-      content_type = request.content_type ||
-          last_env['CONTENT-TYPE'] ||
-          last_env['Content-Type'] ||
-          last_env['CONTENT_TYPE']
-
-      content_type.present? ? content_type : nil
     end
 
     def content_type_equals?(type)

--- a/lib/sparrow/request_middleware.rb
+++ b/lib/sparrow/request_middleware.rb
@@ -7,5 +7,23 @@ module Sparrow
       strategy.handle(env, :request)
       env
     end
+
+    def content_type
+      my_content_type = request.content_type ||
+          last_env['CONTENT-TYPE'] ||
+          last_env['Content-Type'] ||
+          last_env['CONTENT_TYPE']
+
+      my_content_type.present? ? my_content_type : nil
+    end
+
+    def strategy
+      if is_processable? && last_env[Strategies::FormHash::REQUEST_FORM_HASH_KEY]
+        Rails.logger.debug 'Choosing strategy FormHash' if defined? Rails
+        Strategies::FormHash
+      else
+        super
+      end
+    end
   end
 end

--- a/lib/sparrow/response_middleware.rb
+++ b/lib/sparrow/response_middleware.rb
@@ -33,5 +33,12 @@ module Sparrow
     def unprocessable_status?
       @status.in?(500..511) || @status == 404
     end
+
+    def content_type
+      headers['Content-Type'].split(';').first #||
+          # last_env['CONTENT-TYPE'] ||
+          # last_env['Content-Type'] ||
+          # last_env['CONTENT_TYPE']
+    end
   end
 end

--- a/lib/sparrow/strategies/ignore.rb
+++ b/lib/sparrow/strategies/ignore.rb
@@ -34,6 +34,10 @@ module Sparrow
         @env
       end
 
+      def json_body
+        params
+      end
+
       def transform_params
         ensure_json
       end

--- a/spec/integration/apps/rails_app/app/controllers/welcome_controller.rb
+++ b/spec/integration/apps/rails_app/app/controllers/welcome_controller.rb
@@ -11,6 +11,10 @@ class WelcomeController < ApplicationController
     render json: {keys: extract_keys, camelCase: false, snake_case: true}
   end
 
+  def non_json_response
+    render text: "----- BEGIN PUBLIC KEY -----\n#{extract_keys}\n----- END PUBLIC KEY -----"
+  end
+
   def posts
     render json: {keys: extract_keys}
   end

--- a/spec/integration/apps/rails_app/config/routes.rb
+++ b/spec/integration/apps/rails_app/config/routes.rb
@@ -51,9 +51,11 @@ Dummy::Application.routes.draw do
   root :to => 'welcome#index', defaults: { format: 'json' }
   post '/posts' => 'welcome#posts', defaults: {format: 'json'}
   get '/welcome' => 'welcome#show', default: {format: 'json'}
+  get '/welcome/non_json_response' => 'welcome#non_json_response', default: {format: 'json'}
   get '/array_of_elements' => 'welcome#array_of_elements', default: {format: 'json'}
   get '/upcase_first_name' => 'welcome#upcase_first_name', default: {format: 'json'}
   get '/ignore' => 'welcome#ignore', default: {format: 'json'}
+  get '/ignore/non_json_response' => 'welcome#non_json_response', default: {format: 'json'}
   get '/error' => 'welcome#error', default: {format: 'json'}
 
   # See how all your routes lay out with "rake routes"


### PR DESCRIPTION
Previously both the request strategy and the response strategy were decided upon the content-type of the _request_ only. This is obviously wrong for requests where json goes in and non-json goes out.

So now the strategy is decided on the content-type of request and response individually. For this the determination of the content_type had to be moved into the response_middleware and request_middleware.

Pair programmed by @enricogenauck and me.