### PR TITLE
Underscore request parameters by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Example:
 
 ### default_json_request_key_transformation_strategy
 
-> `String`. Default: `camelize`
+> `String`. Default: `underscore`
 
 Defines how the middleware should treat incoming parameters via Request. Which means how they get tranformed, i.e. defining _underscore_ here means that incoming parameters get underscore. Possible values are _underscore_ and _camelize_
 

--- a/lib/sparrow/configuration.rb
+++ b/lib/sparrow/configuration.rb
@@ -21,7 +21,7 @@ module Sparrow
       @json_request_format_header                        = 'request-json-format'
       @json_response_format_header                       = 'response-json-format'
       @excluded_routes                                   = []
-      @default_json_request_key_transformation_strategy  = :camelize
+      @default_json_request_key_transformation_strategy  = :underscore
       @default_json_response_key_transformation_strategy = :camelize
       @camelize_ignore_uppercase_keys                    = true
       @allowed_content_types                             = %w[


### PR DESCRIPTION
This seems to be a better default strategy for rubyists :)