### PR TITLE
Refine hash instead of monkey patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 .idea
 .project
 hoogfile.yml
+.tags*

--- a/lib/sparrow/configuration.rb
+++ b/lib/sparrow/configuration.rb
@@ -35,6 +35,10 @@ module Sparrow
       @camelize_strategy      = :lower
     end
 
+    def active_support_legacy_version
+      /3\.\d+\.\d+/
+    end
+
     ##
     # @param type [String] the http message type.
     #   Must be either 'request' or 'response'.

--- a/lib/sparrow/core_ext/hash.rb
+++ b/lib/sparrow/core_ext/hash.rb
@@ -1,23 +1,28 @@
-class Hash
-  # Defines deep_transform_keys as available in ActiveSupport >= 4.0.2.
-  # See {http://apidock.com/rails/v4.2.1/Hash/deep_transform_keys}
-  def deep_transform_keys(&block)
-    deep_transform_in_object(self, &block)
-  end
-
-  private 
-
-  def deep_transform_in_object(obj, &block)
-    case obj 
-      when Hash
-        obj.each_with_object({}) do |(key,value), result|
-          result[yield(key)] = deep_transform_in_object(value, &block)
+module Sparrow
+  module CoreExt
+    module Hash
+      refine ::Hash do
+        # Defines deep_transform_keys as available in ActiveSupport >= 4.0.2.
+        # See {http://apidock.com/rails/v4.2.1/Hash/deep_transform_keys}
+        def deep_transform_keys(&block)
+          deep_transform_in_object(self, &block)
         end
-      when Array
-        obj.map { |el| deep_transform_in_object(el, &block) }
-      else
-        obj
+
+        private
+
+        def deep_transform_in_object(obj, &block)
+          case obj
+            when ::Hash
+              obj.each_with_object({}) do |(key,value), result|
+                result[yield(key)] = deep_transform_in_object(value, &block)
+              end
+            when Array
+              obj.map { |el| deep_transform_in_object(el, &block) }
+            else
+              obj
+          end
+        end
+      end
     end
   end
 end
-

--- a/lib/sparrow/dependencies.rb
+++ b/lib/sparrow/dependencies.rb
@@ -2,7 +2,16 @@ require 'active_support/core_ext/object'
 require 'active_support/core_ext/string'
 require 'active_support/version'
 
-if ActiveSupport::VERSION::STRING.match(/3\.\d+\.\d+/)
+module Sparrow
+  module_function
+
+  def uses_active_support_legacy_version?
+    active_support_legacy_version = /3\.\d+\.\d+/
+    ActiveSupport::VERSION::STRING.match(active_support_legacy_version)
+  end
+end
+
+if Sparrow.uses_active_support_legacy_version?
   require 'sparrow/core_ext/hash'
   require 'active_support/core_ext/object/to_param'
   require 'active_support/core_ext/object/to_query'

--- a/lib/sparrow/strategies/transform_params.rb
+++ b/lib/sparrow/strategies/transform_params.rb
@@ -3,6 +3,10 @@ module Sparrow
     ##
     # Core class to trigger the conversion
     class TransformParams
+      if Sparrow.uses_active_support_legacy_version?
+        using Sparrow::CoreExt::Hash
+      end
+
       ##
       # the strategy stating how to convert the JSON
       # @return [KeyTransformation] key transformation strategy


### PR DESCRIPTION
Use refining core classes instead of monkey patching them

    The monkey patch of the Ruby core class Hash isn't necessary
    when refining the class by adding to methods to extend within
    the refinement. As the methodes are only used to provide backwards
    compatibility for Rails 3 the monkey patching was removed from
    the code.