### PR TITLE
Make the gem requireable by Bundler by default

### DIFF
--- a/lib/cp-sparrow.rb
+++ b/lib/cp-sparrow.rb
@@ -1,0 +1,1 @@
+require 'sparrow'


### PR DESCRIPTION
This file will allow gem users to simply write `gem 'cp-sparrow'` in `Gemfile`