### PR TITLE
Make the gem requireable by Bundler by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Rack middleware for converting the params keys and JSON response keys of a Rac
 
 Add this line to your application's Gemfile:
 
-    gem 'cp-sparrow', require: 'sparrow'
+    gem 'cp-sparrow'
 
 And then execute:
 

--- a/lib/cp-sparrow.rb
+++ b/lib/cp-sparrow.rb
@@ -1,0 +1,1 @@
+require 'sparrow'


### PR DESCRIPTION
This file will allow gem users to simply write `gem 'cp-sparrow'` in `Gemfile`